### PR TITLE
Update python depends_on for brew 1.5

### DIFF
--- a/Formula/punic.rb
+++ b/Formula/punic.rb
@@ -5,7 +5,7 @@ class Punic < Formula
   sha256 "c5e83050803b1c1f4d236f93101adf97da9c8c6a1ca2a3dd275c0010d1f7b9c4"
 
   depends_on "libyaml"
-  depends_on :python
+  depends_on "python"
 
   resource "affirm" do
     url "https://files.pythonhosted.org/packages/5d/93/7ef39cb4db23550b041c79052b53e8594e92f6288369cec7ef572a935c5c/affirm-0.9.2.tar.gz"

--- a/Formula/punic.rb
+++ b/Formula/punic.rb
@@ -5,7 +5,7 @@ class Punic < Formula
   sha256 "c5e83050803b1c1f4d236f93101adf97da9c8c6a1ca2a3dd275c0010d1f7b9c4"
 
   depends_on "libyaml"
-  depends_on "python"
+  depends_on "python@2" if MacOS.version <= :snow_leopard
 
   resource "affirm" do
     url "https://files.pythonhosted.org/packages/5d/93/7ef39cb4db23550b041c79052b53e8594e92f6288369cec7ef572a935c5c/affirm-0.9.2.tar.gz"


### PR DESCRIPTION
[Homebrew 1.5](https://brew.sh/2018/01/19/homebrew-1.5.0/) will update it's python to version 3 and has deprecated the `depends_on :python`, the message you'll see as of today:

```sh
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/schwa/homebrew-punic/Formula/punic.rb:8:in `<class:Punic>'
Please report this to the schwa/punic tap!
```